### PR TITLE
UPDATE facets for upcoming ceres version

### DIFF
--- a/resources/css/main.scss
+++ b/resources/css/main.scss
@@ -271,29 +271,35 @@
 }
 
 /* Facet extension */
-.filter-wrapper #filterCollapse
+.filter-wrapper #filterCollapse,
+.selected-filters
 {
-    [for="option-feedback-5"]::after{
+    [for="option-feedback-5"]::after,
+    .filter-feedback-5::before {
         content: "\f005 \f005 \f005 \f005 \f005" !important;
         font-family: FontAwesome;
         letter-spacing: 3px;
     }
-    [for="option-feedback-4"]::after{
+    [for="option-feedback-4"]::after,
+    .filter-feedback-4::before{
         content: "\f005 \f005 \f005 \f005  \f062" !important;
         font-family: FontAwesome;
         letter-spacing: 3px;
     }
-    [for="option-feedback-3"]::after{
+    [for="option-feedback-3"]::after,
+    .filter-feedback-3::before{
         content: "\f005 \f005 \f005  \f062" !important;
         font-family: FontAwesome;
         letter-spacing: 3px;
     }
-    [for="option-feedback-2"]::after{
+    [for="option-feedback-2"]::after,
+    .filter-feedback-2::before{
         content: "\f005 \f005  \f062" !important;
         font-family: FontAwesome;
         letter-spacing: 3px;
     }
-    [for="option-feedback-1"]::after{
+    [for="option-feedback-1"]::after,
+    .filter-feedback-1::before{
         content: "\f005  \f062" !important;
         font-family: FontAwesome;
         letter-spacing: 3px;

--- a/src/Extensions/FeedbackFacet.php
+++ b/src/Extensions/FeedbackFacet.php
@@ -2,6 +2,7 @@
 namespace Feedback\Extensions;
 
 use IO\Services\ItemLoader\Contracts\FacetExtension;
+use IO\Services\SessionStorageService;
 use Plenty\Modules\Cloud\ElasticSearch\Lib\Search\Aggregation\AggregationInterface;
 use Plenty\Modules\Item\Search\Aggregations\FeedbackAggregation;
 use Plenty\Modules\Item\Search\Aggregations\FeedbackAggregationProcessor;
@@ -40,8 +41,24 @@ class FeedbackFacet implements FacetExtension
 
             $this->getLogger('merge into facets')->debug('Feedback::Debug.filterResponse', $result['feedback']);
 
+            $facetName = '';
+            
+            // TODO: get facet name from property file
+            $lang = pluginApp( SessionStorageService::class )->getLang();
+            if ( $lang === 'de' )
+            {
+                $facetName = 'Artikelbewertung';
+            }
+            else
+            {
+                $facetName = 'Item rating';
+            }
+            
             $feedback = [
                 'id' => 'feedback',
+                'name' => $facetName,
+                'position' => 10, //TODO: load from config
+                // TODO: still required?
                 'names' => [
                     ['lang' => 'de', 'name' => 'Artikelbewertung'],
                     ['lang' => 'en', 'name' => 'Item rating'],
@@ -54,9 +71,10 @@ class FeedbackFacet implements FacetExtension
                     $feedback['values'][] = [
                         'id' => 'feedback-' . $i,
                         'names' => [
-                            ['lange' => 'de', 'name' => '']
+                            ['lang' => 'de', 'name' => '']
                         ],
-                        'total' => $result['feedback'][$i]
+                        'count' => $result['feedback'][$i],
+                        'total' => $result['feedback'][$i] //TODO: remove after release of Ceres with new facet logic
                     ];
                 }
             }


### PR DESCRIPTION
@ptopczewski 

Hey Topo, wir haben ein paar Anpassungen vorgenommen, weil sich bei Ceres und IO im nächsten release die Logik für die Facetten ändert. Hiermit ist sichergestellt, dass das Feedback Plugin auch mit der neuen Version wie gewünscht funktioniert. Abwärtskompatibel sind die Änderungen aber auch. Im Code sind allerdings noch ein paar TODOs, die du oder dein Team übernehmen solltet. (nicht wegen der neuen Ceres Version sondern generell)
Wir haben bei der Gelegenheit auch noch Kleinigkeiten am CSS gemacht, weil vorher der Badge bei den ausgewählten Filtern leer angezeigt wurde.

![bildschirmfoto 2017-12-15 um 16 57 22](https://user-images.githubusercontent.com/4144472/34049844-2b5042ae-e1b9-11e7-8d24-b3c5d304ad00.png)

Wenn du noch Fragen hast meld dich bei mir ;)
