### PR TITLE
Harden paginate function against missing items

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,5 +1,5 @@
 {
-    "version": "3.2.0",
+    "version": "3.2.1",
     "name": "Feedback",
     "marketplaceName": {
         "de": "Kunden-Feedback",

--- a/resources/lang/de/Debug.properties
+++ b/resources/lang/de/Debug.properties
@@ -1,1 +1,2 @@
 filterResponse=Filter Antwort
+FeedbackService_itemDoesNotExistError=Der angeforderte Artikel existiert nicht

--- a/resources/lang/en/Debug.properties
+++ b/resources/lang/en/Debug.properties
@@ -1,1 +1,2 @@
 filterResponse=Filter response
+FeedbackService_itemDoesNotExistError=The requested item does not exist

--- a/src/Services/FeedbackService.php
+++ b/src/Services/FeedbackService.php
@@ -287,7 +287,7 @@ class FeedbackService
         }
         catch(\Exception $e)
         {
-            $this->getLogger(__METHOD__)->error("Feedback::FeedbackService_itemDoesNotExistError", [
+            $this->getLogger(__METHOD__)->error("Feedback::Debug.FeedbackService_itemDoesNotExistError", [
                 'code' => $e->getCode(),
                 'message' => $e->getMessage(),
                 'itemId' => $itemId

--- a/src/Services/FeedbackService.php
+++ b/src/Services/FeedbackService.php
@@ -2,7 +2,6 @@
 
 namespace Feedback\Services;
 
-use Aws\CloudFront\Exception\Exception;
 use Plenty\Modules\Authorization\Services\AuthHelper;
 use Plenty\Plugin\Http\Request;
 use Feedback\Helpers\FeedbackCoreHelper;
@@ -291,6 +290,7 @@ class FeedbackService
             $this->getLogger( __METHOD__)
                 ->logException($e);
         }
+
         foreach ($itemDataList['variations'] as $itemData) {
             $itemVariations[] = $itemData['id'];
         }
@@ -496,7 +496,8 @@ class FeedbackService
      * @param $variationId
      * @return bool
      */
-    private function hasPurchasedVariation($contactId, $variationId) {
+    private function hasPurchasedVariation($contactId, $variationId)
+    {
         $allowFeedbacksOnlyIfPurchased = $this->request->input("allowFeedbacksOnlyIfPurchased") === 'true';
         $hasPurchased = true;
 

--- a/src/Services/FeedbackService.php
+++ b/src/Services/FeedbackService.php
@@ -287,8 +287,11 @@ class FeedbackService
         }
         catch(\Exception $e)
         {
-            $this->getLogger( __METHOD__)
-                ->logException($e);
+            $this->getLogger(__METHOD__)->error("Feedback::FeedbackService_itemDoesNotExistError", [
+                'code' => $e->getCode(),
+                'message' => $e->getMessage(),
+                'itemId' => $itemId
+            ]);
         }
 
         foreach ($itemDataList['variations'] as $itemData) {


### PR DESCRIPTION
@plentymarkets/ceres-io 

Catch a 500, defuse it with an empty array.
Crit happens, when feedbacks for an item, that does not exist, are tried to be fetched.