### PR TITLE
use getBoundingClientRect instead of offsetTop

### DIFF
--- a/resources/views/Components/FeedbackAverage/FeedbackAverage_component.twig
+++ b/resources/views/Components/FeedbackAverage/FeedbackAverage_component.twig
@@ -45,7 +45,7 @@
 
                     if(feedbackWidget !== null)
                     {
-                        var elementTop = feedbackWidget.offsetTop;
+                        var elementTop = feedbackWidget.getBoundingClientRect().top + window.scrollY;
                         window.scrollTo(
                             {
                                 top: elementTop,

--- a/resources/views/Components/FeedbackAverage/FeedbackAverage_component.twig
+++ b/resources/views/Components/FeedbackAverage/FeedbackAverage_component.twig
@@ -42,10 +42,12 @@
 
                 scrollTo: function() {
                     var feedbackWidget = document.querySelector("[data-feedback]");
+                    var headerMargin = document.querySelector("#vue-app").offsetTop;
 
                     if(feedbackWidget !== null)
                     {
-                        var elementTop = feedbackWidget.getBoundingClientRect().top + window.scrollY;
+                        var elementTop = feedbackWidget.getBoundingClientRect().top + window.scrollY - headerMargin;
+
                         window.scrollTo(
                             {
                                 top: elementTop,


### PR DESCRIPTION
@plentymarkets/ceres-io 

Previously used offsetTop does not work in certain situations, where the feedback widget is nested