### PR TITLE
feature: display feedback order widget only if order has been completed

### DIFF
--- a/resources/lang/de/Widget.properties
+++ b/resources/lang/de/Widget.properties
@@ -74,6 +74,7 @@ showNumberOfRatings = "Anzahl der Bewertungen anzeigen"
 showNumberOfRatingsTooltip = "Aktivieren, um die Anzahl der bisherigen Bewertungen rechts neben den Bewertungssternen anzuzeigen."
 
 ;FeedbackOrderItemWidget
+hideWhenOrderNotCompleted = "Nur anzeigen, wenn die Bestellung abgeschlossen wurde (Warenausgang gebucht)."
 itemsPerRow = "Artikel pro Reihe"
 itemsPerRowTooltip = "Anzahl der Artikel wählen, die pro Reihe angezeigt werden."
 rowsPerPage = "Reihen pro Seite"

--- a/resources/lang/en/Widget.properties
+++ b/resources/lang/en/Widget.properties
@@ -73,6 +73,7 @@ showNumberOfRatings = "Show number of ratings"
 showNumberOfRatingsTooltip = "Activate to show the number of submitted ratings next to the rating stars."
 
 ;FeedbackOrderItemWidget
+hideWhenOrderNotCompleted = "Only display if the order has been completed (goods issue posted)."
 itemsPerRow = "Items per row"
 itemsPerRowTooltip = "Enter the maximum number of items per row."
 rowsPerPage = "Rows per page"

--- a/resources/views/Widgets/FeedbackOrderWidget.twig
+++ b/resources/views/Widgets/FeedbackOrderWidget.twig
@@ -11,12 +11,13 @@
 {{ Twig.set("configOptions", Twig.call("feedbackServices.feedback.getOrderFrontendOptions") ) }}
 {{ Twig.set("options", options | json_encode) }}
 {{ Twig.set("options", "options | merge(configOptions)") }}
+{{ Twig.set("hideWidget", false) }}
 
 {{ Twig.if("data.order is defined and data.order is not null and urls.is('confirmation')") }}
     {{ Twig.if("hideWhenNotCompleted is true and data.order.dates is defined and data.order.dates is not null") }}
-        {{ Twig.set("hideWidget", false) }}
+    {{ Twig.set("hideWidget", true) }}
             {{ Twig.for(dates, data.order.dates, dates.typeId == "5") }}
-                {{ Twig.set("hideWidget", true) }}
+                {{ Twig.set("hideWidget", false) }}
             {{ Twig.endfor() }}
     {{ Twig.endif() }}
     {{ Twig.if("hideWidget is false") }}

--- a/resources/views/Widgets/FeedbackOrderWidget.twig
+++ b/resources/views/Widgets/FeedbackOrderWidget.twig
@@ -3,6 +3,7 @@
 
 {% set customClass = widget.settings.customClass.mobile %}
 {% set appearance = widget.settings.appearance.mobile %}
+{% set hideWhenNotCompleted = widget.settings.hideWhenNotCompleted.mobile %}
 {% set spacingSettings = widget.settings.spacing %}
 {% set inlineMargin    = WidgetHelper.getInlineSpacings(spacingSettings, "", spacingSettings.customMargin.mobile) %}
 {% set spacingMargin   = WidgetHelper.getSpacingClasses(spacingSettings, "",spacingSettings.customMargin.mobile) %}
@@ -12,19 +13,27 @@
 {{ Twig.set("options", "options | merge(configOptions)") }}
 
 {{ Twig.if("data.order is defined and data.order is not null and urls.is('confirmation')") }}
-<div class="widget widget-feedback-orderconfirmation widget-{{ appearance | default("primary") }} {% if customClass | length > 0 %} {{ customClass }}{% endif %} {% if spacingMargin | length > 0 %} {{ spacingMargin }}{% endif %}"
-        {% if inlineMargin | length > 0 %} style="{{ inlineMargin }}"{% endif %}>
-    <feedback-order-container
-            :variations="{{ Twig.print("data.variations | json_encode") }}"
-            :items="{{ Twig.print("data.order.orderItems | json_encode") }}"
-            :item-urls="{{ Twig.print("data.itemURLs | json_encode") }}"
-            :item-images="{{ Twig.print("data.itemImages | json_encode") }}"
-            :options="{{ Twig.print('options | json_encode') }}"
-            :split-item-bundles="{{ Twig.print("splitItemBundle | json_encode") }}"
-            access-key="{{ Twig.print(Twig.call("feedbackServices.feedback.getOrderAccessKey", [Twig.var("data.order.id")])) }}"
-            order-id="{{ Twig.print("data.order.id | json_encode") }}">
-    </feedback-order-container>
-</div>
+    {{ Twig.if("hideWhenNotCompleted is true and data.order.dates is defined and data.order.dates is not null") }}
+        {{ Twig.set("hideWidget", false) }}
+            {{ Twig.for(dates, data.order.dates, dates.typeId == "5") }}
+                {{ Twig.set("hideWidget", true) }}
+            {{ Twig.endfor() }}
+    {{ Twig.endif() }}
+    {{ Twig.if("hideWidget is false") }}
+    <div class="widget widget-feedback-orderconfirmation widget-{{ appearance | default("primary") }} {% if customClass | length > 0 %} {{ customClass }}{% endif %} {% if spacingMargin | length > 0 %} {{ spacingMargin }}{% endif %}"
+            {% if inlineMargin | length > 0 %} style="{{ inlineMargin }}"{% endif %}>
+        <feedback-order-container
+                :variations="{{ Twig.print("data.variations | json_encode") }}"
+                :items="{{ Twig.print("data.order.orderItems | json_encode") }}"
+                :item-urls="{{ Twig.print("data.itemURLs | json_encode") }}"
+                :item-images="{{ Twig.print("data.itemImages | json_encode") }}"
+                :options="{{ Twig.print('options | json_encode') }}"
+                :split-item-bundles="{{ Twig.print("splitItemBundle | json_encode") }}"
+                access-key="{{ Twig.print(Twig.call("feedbackServices.feedback.getOrderAccessKey", [Twig.var("data.order.id")])) }}"
+                order-id="{{ Twig.print("data.order.id | json_encode") }}">
+        </feedback-order-container>
+    </div>
+    {{ Twig.endif() }}
 {{ Twig.elseif("#{ isPreview | json_encode } and not urls.is('confirmation')") }}
 <div class="widget-placeholder">
     <div>

--- a/src/Widgets/FeedbackOrderWidget.php
+++ b/src/Widgets/FeedbackOrderWidget.php
@@ -62,6 +62,11 @@ class FeedbackOrderWidget extends OrderConfirmationBaseWidget
             ->withName('Widget.rowsPerPage')
             ->withTooltip('Widget.rowsPerPageTooltip');
 
+        $settings->createSetting('hideWhenNotCompleted')
+            ->withType('checkbox')
+            ->withDefaultValue(false)
+            ->withName('Widget.hideWhenOrderNotCompleted');
+
         return $settings->toArray();
     }
 


### PR DESCRIPTION
### All changes meet the following requirements
- [ ] Changelog entry was added
- [ ] Changes have been documented
- [ ] Changes have been tested by the author
- [ ] Changes have been tested by the reviewer
- [ ] Plugin can be built

@plentymarkets/plentyshop

This feature implements an option to hide the feedback widget on the order confirmation page, when the order has not been completed. 

Missing feature has been mentioned here: https://forum.plentymarkets.com/t/feedback-zum-widget-kundenbewertung-in-der-bestelluebersicht/621162